### PR TITLE
Suppress tar warnings on APFS

### DIFF
--- a/lib/kitchen/transport/speedy_ssh.rb
+++ b/lib/kitchen/transport/speedy_ssh.rb
@@ -45,7 +45,8 @@ module Kitchen
         end
 
         def archive_locally(path, archive_path)
-          "tar -cf #{archive_path} -C #{::File.dirname(path)} #{::File.basename(path)}"
+          "tar --warning=no-unknown-keyword -cf #{archive_path} " \
+            "-C #{::File.dirname(path)} #{::File.basename(path)}"
         end
 
         def dearchive_remotely(archive_basename, remote)


### PR DESCRIPTION
Tar does not recognize extended APFS file headers. 

This fix suppresses blind scrolling even in a non-debug converge.

```
tar: Ignoring unknown extended header keyword `SCHILY.dev'
tar: Ignoring unknown extended header keyword `SCHILY.ino'
```

http://lifeonubuntu.com/tar-errors-ignoring-unknown-extended-header-keyword/